### PR TITLE
Fixes use of custom recording path.

### DIFF
--- a/ReSwiftRecorder/RecordingStore.swift
+++ b/ReSwiftRecorder/RecordingStore.swift
@@ -157,7 +157,7 @@ public class RecordingMainStore<State: StateType>: Store<State> {
         //        let path = documentDirectoryURL?
         //            .URLByAppendingPathComponent("recording_\(timestamp).json")
         let path = documentDirectoryURL?
-            .URLByAppendingPathComponent("recording.json")
+            .URLByAppendingPathComponent(self.recordingPath ?? "recording.json")
 
         print("Recording to path: \(path)")
         return path


### PR DESCRIPTION
Current implementation ignores custom recording paths.

This patch uses the custom if any available else the default `recording.json`

This defo needs some tweaks in case its a path, needs validation, etc but for now this at least respects the passed in parameter.
