### PR TITLE
deprecate the repo

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" "master"
+github "ReSwift/ReSwift" "3.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReSwift/ReSwift" "8d6efaf2367fcd4daf4cc1b8f5b1fe0af5310d14"
+github "ReSwift/ReSwift" "3.0.0"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) 
 [![](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Swift-Flow/Swift-Flow/blob/master/LICENSE.md)
 
-⚠️ **Proof of concept. Needs a lot of love!** ⚠️
+A recording store for [ReSwift][]. Enables hot-reloading and time travel for ReSwift apps.
 
-A recording store for [ReSwift](https://github.com/ReSwift/ReSwift). Enables hot-reloading and time travel for ReSwift apps.
+# ⚠️ ReSwift-Recorder is Deprecated
+
+⚠️ Proof of concept. Needs a lot of love! ⚠️
+
+The recorder was written to work with [ReSwift][] v3. It uses an internal state setter which is not supported by more recent releases of ReSwift; so the recorder would need to be rewritten.
+
+[reswift]: https://github.com/ReSwift/ReSwift
 
 # About ReSwiftRecorder
 

--- a/ReSwiftRecorder.podspec
+++ b/ReSwiftRecorder.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target     = '8.0'
   s.requires_arc = true
   s.source_files     = 'ReSwiftRecorder/**/*.swift'
-  s.dependency 'ReSwift', '~> 4.0'
+  s.dependency 'ReSwift', '~> 3.0.0'
 end


### PR DESCRIPTION
We changed ReSwift so the proof of concept here doesn't work the way it did before. See https://github.com/ReSwift/ReSwift/issues/303